### PR TITLE
Prepend thesdk module to PYTHONPATH

### DIFF
--- a/sourceme.csh
+++ b/sourceme.csh
@@ -11,7 +11,7 @@ set scriptdir=`dirname $scriptfp`
 if ( ! $?PYTHONPATH ) then
     setenv PYTHONPATH $scriptdir/Entities/thesdk
 else
-    setenv PYTHONPATH ${PYTHONPATH}:$scriptdir/Entities/thesdk
+    setenv PYTHONPATH $scriptdir/Entities/thesdk:${PYTHONPATH}
 endif
 
 if ( -d ${HOME}/.local/bin && "${PATH}" !~ *"${HOME}/.local/bin"* ) then


### PR DESCRIPTION
PYTHONPATH is searched in order from left to right. When working with
multiple TheSyDeKick projects the first thesdk path appended to PYTHONPATH
always has precedence and will be used even after sourcing another
project's sourceme.csh. Instead, by prepending thesdk path to PYTHONPATH
the latest sourced project always has precedence and switching to another
project can be done by simply sourcing sourceme.csh in the new project.

Fixes #14 